### PR TITLE
Fixes github clone url in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -169,7 +169,7 @@ First, install Python(2.7) on your machine, then run the following:
 .. code:: bash
 
    # Clone the repository
-   $ git clone git@github.com/awslabs/aws-sam-cli.git
+   $ git clone git@github.com:awslabs/aws-sam-cli.git
 
    # cd into the git
    $ cd aws-sam-cli


### PR DESCRIPTION
*Issue #, if available:*

None

*Description of changes:*

Fixes the github clone URL in the Readme. Copy and pasting the current command yields:

```
fatal: repository 'git@github.com/awslabs/aws-sam-cli.git' does not exist
```

After this change you receive:

```
Cloning into 'aws-sam-cli'...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
